### PR TITLE
Content-fetch Dockerfile

### DIFF
--- a/packages/content-fetch/Dockerfile
+++ b/packages/content-fetch/Dockerfile
@@ -1,18 +1,14 @@
-FROM node:18.16-alpine AS build
+FROM node:22.12-alpine AS build
 LABEL org.opencontainers.image.source="https://github.com/omnivore-app/omnivore"
 
 # Installs latest Chromium package and other dependencies.
-RUN echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
-&& echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \
-&& echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories  \
-&& apk -U upgrade \
+RUN apk -U upgrade \
 && apk add --no-cache \
-    g++@edge \
-    make@edge \
-    python3 && \
-    node && \
-    yarn && \
-    rm -rf /var/cache/apk/*
+    g++ \
+    make \
+    python3 \
+    py3-pip && \
+    rm -rf /var/cache/apk/* 
 
 WORKDIR /app
 
@@ -41,7 +37,7 @@ RUN yarn workspace @omnivore/utils build && \
     yarn install --pure-lockfile --production
 
 # Running stage
-FROM node:18.16-alpine
+FROM node:22.12-alpine
 
 RUN echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
 && echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \

--- a/packages/content-fetch/Dockerfile
+++ b/packages/content-fetch/Dockerfile
@@ -1,29 +1,26 @@
-FROM node:22.12
+FROM node:18.16-alpine AS build
 LABEL org.opencontainers.image.source="https://github.com/omnivore-app/omnivore"
 
-# Installs latest Chromium package.
-RUN apt-get update && apt-get install -y \
-    chromium \
-    firefox-esr \
-    ca-certificates \
-    nodejs \
-    yarn \
-    g++ \
-    make \
-    python3
+# Installs latest Chromium package and other dependencies.
+RUN echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
+&& echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \
+&& echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories  \
+&& apk -U upgrade \
+&& apk add --no-cache \
+    g++@edge \
+    make@edge \
+    python3 && \
+    node && \
+    yarn && \
+    rm -rf /var/cache/apk/*
 
 WORKDIR /app
 
-ENV CHROMIUM_PATH /usr/bin/chromium
-ENV FIREFOX_PATH /usr/bin/firefox
+ENV CHROMIUM_PATH=/usr/bin/chromium
+ENV FIREFOX_PATH=/usr/bin/firefox
 ENV LAUNCH_HEADLESS=true
 
-COPY package.json .
-COPY yarn.lock .
-COPY tsconfig.json .
-COPY .prettierrc .
-COPY .eslintrc .
-
+COPY package.json yarn.lock tsconfig.json .prettierrc .eslintrc ./
 COPY /packages/content-fetch/package.json ./packages/content-fetch/package.json
 COPY /packages/content-handler/package.json ./packages/content-handler/package.json
 COPY /packages/puppeteer-parse/package.json ./packages/puppeteer-parse/package.json
@@ -31,29 +28,50 @@ COPY /packages/utils/package.json ./packages/utils/package.json
 
 RUN yarn install --pure-lockfile
 
-ADD /packages/content-fetch ./packages/content-fetch
-ADD /packages/content-handler ./packages/content-handler
-ADD /packages/puppeteer-parse ./packages/puppeteer-parse
-ADD /packages/utils ./packages/utils
-RUN yarn workspace @omnivore/utils build
-RUN yarn workspace @omnivore/content-handler build
-RUN yarn workspace @omnivore/puppeteer-parse build
-RUN yarn workspace @omnivore/content-fetch build
+COPY /packages/content-fetch ./packages/content-fetch
+COPY /packages/content-handler ./packages/content-handler
+COPY /packages/puppeteer-parse ./packages/puppeteer-parse
+COPY /packages/utils ./packages/utils
 
-# After building, fetch the production dependencies
-RUN rm -rf /app/packages/content-fetch/node_modules
-RUN rm -rf /app/node_modules
-RUN yarn install --pure-lockfile --production
+RUN yarn workspace @omnivore/utils build && \
+    yarn workspace @omnivore/content-handler build && \
+    yarn workspace @omnivore/puppeteer-parse build && \
+    yarn workspace @omnivore/content-fetch build && \
+    rm -rf /app/packages/content-fetch/node_modules /app/node_modules && \
+    yarn install --pure-lockfile --production
+
+# Running stage
+FROM node:18.16-alpine
+
+RUN echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
+&& echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \
+&& echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories  \
+&& apk -U upgrade \
+&& apk add --no-cache \
+    firefox@edge \
+    freetype@edge \
+    ttf-freefont@edge \
+    nss@edge \
+    libstdc++@edge \
+    sqlite-libs@edge \
+    chromium@edge \
+    firefox-esr@edge \
+    ca-certificates@edge \
+    rm -rf /var/cache/apk/*
+
+WORKDIR /app
+
+ENV CHROMIUM_PATH=/usr/bin/chromium
+ENV FIREFOX_PATH=/usr/bin/firefox
+ENV LAUNCH_HEADLESS=true
+
+COPY --from=build /app /app
 
 EXPOSE 8080
 
 # In Firefox we can't use the adblocking sites. Adding them to the hosts file of the docker seems to work.
-RUN wget https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
-RUN echo "#!/bin/bash \n\
-cat hosts >> /etc/hosts \n\
-yarn workspace @omnivore/content-fetch start" >> ./start.sh
-
-RUN chmod +x ./start.sh
+COPY /packages/content-fetch/start.sh .
+RUN wget https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts && \
+    chmod +x start.sh
 
 CMD ["./start.sh"]
-

--- a/packages/content-fetch/start.sh
+++ b/packages/content-fetch/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cat hosts >> /etc/hosts
+yarn workspace @omnivore/content-fetch start


### PR DESCRIPTION
This pull request includes significant changes to the `Dockerfile` in the `packages/content-fetch` directory. The main focus is on updating the Dockerfile to use a multi-stage build process and optimizing the installation of dependencies.

### Dockerfile improvements:

* Changed the base image to `node:18.16-alpine` for a lighter and more secure build environment.
* Implemented a multi-stage build process to separate the build and runtime environments, reducing the final image size.
* Combined multiple `COPY` commands to streamline the Dockerfile and reduce the number of layers.
* Added start script as a file

No changes to RAM usage, but lowered final image size to ~1.4 Gb 